### PR TITLE
💎 Updated dependencies

### DIFF
--- a/checkstyle/java.gradle
+++ b/checkstyle/java.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'checkstyle'
 
 checkstyle {
-    toolVersion '8.1'
+    toolVersion '8.3'
     configFile rootProject.file('config/checkstyle/checkstyle.xml')
     ignoreFailures false
     showViolations true

--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -9,7 +9,7 @@ android {
 }
 
 jacoco {
-    toolVersion "0.7.6.201602180812"
+    toolVersion "0.7.9"
 }
 
 jacocoAndroidUnitTestReport {

--- a/versions.gradle
+++ b/versions.gradle
@@ -12,11 +12,11 @@ ext.CONFIG.versions = [
   android: [
     libraries: [
       playServices: '11.0.4',
-      support:      '26.0.0',
+      support:      '27.0.0',
       volley:       '1.0.0',
     ],
-    plugin: '2.3.3',
-    tools:  '26.0.1',
+    plugin: '3.0.0',
+    tools:  '26.0.2',
     sdk: [
       compile: 26,
       target:  26,
@@ -27,16 +27,16 @@ ext.CONFIG.versions = [
   // Third party dependencies of our SDK
   thirdParty: [
     autoParcelGson: '0.2',
-    gson:           '2.8.1',
+    gson:           '2.8.2',
     threetenbp:     '1.3.6',
   ],
 
   // Internal shadows
   internal: [
     timber: '4.+',
-    dagger: '2.11',
+    dagger: '2.12',
     okio:   '1.13.0',
-    okhttp: '3.8.1',
+    okhttp: '3.9.0',
   ]
 ]
 // vim:et:sts=2:sw=2:ts=2:ff=unix:


### PR DESCRIPTION
- [x] Checkstyle ~8.1~ → 8.3
- [x] JaCoCo ~0.7.6.201602180812~ → 0.7.9
- [x] Support libraries ~26.0.0~ → 27.0.0
- [x] AGP ~2.3.3~ → 3.0.0
- [x] Android tools ~26.0.1~ → 26.0.2
- [x] GSON ~2.8.1~ → 2.8.2
- [x] Dagger ~2.11~ → 2.12
- [x] OkHTTP ~3.8.1~ → 3.9.0