### PR TITLE
fix: remove findbugs annotations dependency because they are `Class` retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ apply from: '../config/quality/findbugs/android.gradle'
 findbugs {
   showProgress = false
 }
+// if you want to use findbugs annotations:
+dependencies {
+  compile 'com.google.code.findbugs:annotations:3.0.0'
+}
 ```
 
 ## Default Configurations

--- a/quality/findbugs/android.gradle
+++ b/quality/findbugs/android.gradle
@@ -25,7 +25,3 @@ task findbugs(type: FindBugs,
     html.enabled = true
   }
 }
-
-dependencies {
-  provided 'com.google.code.findbugs:annotations:3.0.0'
-}


### PR DESCRIPTION
Putting them in as `provided` dependency will break clients consuming libraries without the dependency.
Do we want these annotations as transitive dependency? -> I don't think so. But annotations are the best way to suppress the warnings IMO