### PR TITLE
quality(pmd) exculde `AvoidFieldNameMatchingMethodName` rule by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ To ensure usability we follow these rules:
 * Major version changes must also provide a migration guide from the previous major version
 
 ## Versions <a name="versions"></a>
+### 1.2.0 (In Progress)
+* Quality/Pmd: Exclude `AvoidFieldNameMatchingMethodName` rule as google style mentions nothing about getters and setters.
+
 ### 1.1.0 (2018-01-16)
 * Documantation: Add doclava javadoc generation
 * Quality/Checkstyl: Change checkstyle severity from `warning` to `error` so that non-compliant code fails the build (can still be disabled with `ignoreFailues` flag in quality task extensions)

--- a/quality/pmd/pmd-ruleset.xml
+++ b/quality/pmd/pmd-ruleset.xml
@@ -153,6 +153,7 @@
         <exclude name="LongVariable"/>
         <exclude name="ShortMethodName"/>
         <exclude name="AbstractNaming"/>
+        <exclude name="AvoidFieldNameMatchingMethodName"/>
     </rule>
 
     <!-- Optimization (https://pmd.github.io/latest/pmd-java/rules/java/optimizations.html) -->


### PR DESCRIPTION
Exclude `AvoidFieldNameMatchingMethodName` rule from pmd rule set to avoid unnecessary errors as there is nothing mentioned in google style about getters and setters.