### PR TITLE
quality(pmd) disable `final` for parameters and `/* default */` "modi…

### DIFF
--- a/quality/pmd/pmd-ruleset.xml
+++ b/quality/pmd/pmd-ruleset.xml
@@ -56,6 +56,7 @@
     <rule ref="rulesets/java/comments.xml">
         <exclude name="CommentRequired"/>
         <exclude name="CommentSize"/>
+        <exclude name="CommentDefaultAccessModifier"/>
     </rule>
 
     <!-- Controversial (https://pmd.github.io/latest/pmd-java/rules/java/controversial.html) -->
@@ -159,6 +160,7 @@
     <!-- Optimization (https://pmd.github.io/latest/pmd-java/rules/java/optimizations.html) -->
     <rule ref="rulesets/java/optimizations.xml">
         <exclude name="LocalVariableCouldBeFinal"/>
+        <exclude name="MethodArgumentCouldBeFinal"/>
     </rule>
 
     <!-- Strict Exceptions (https://pmd.github.io/latest/pmd-java/rules/java/strictexception.html) -->


### PR DESCRIPTION
…fier"

these rules clutter the code base too much, reducing readability, so
we turn them off.