### PR TITLE
quality(findbugs): setup complete classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ To ensure usability we follow these rules:
 
 ## Versions <a name="versions"></a>
 ### 1.2.0 (In Progress)
-* Quality/Pmd: Exclude `AvoidFieldNameMatchingMethodName` rule as google style mentions nothing about getters and setters.
+* Quality/Pmd: Exclude `AvoidFieldNameMatchingMethodName`, `JUnitTestContainsTooManyAsserts`, `CommentDefaultAccessModifier`, `MethodArgumentCouldBeFinal` rules
+* Quality/Checkstyle: Add support for `@SuppressWarnings("checkstyle:RuleName)` suppression of checkstyle rules
+* Quality/Findbugs: Setup complete classpath for findbugs task, relying on `android.libraryVariants`. Note that this does not work on android applications, but can be adapted to that usecase if it becomes necessary 
 
 ### 1.1.0 (2018-01-16)
 * Documantation: Add doclava javadoc generation

--- a/quality/findbugs/android.gradle
+++ b/quality/findbugs/android.gradle
@@ -1,24 +1,30 @@
 apply plugin: 'findbugs'
 
+import java.nio.file.Paths
+
 findbugs {
   toolVersion = "3.0.1" // see https://github.com/findbugsproject/findbugs/releases
   effort = 'max' //  min, default, or max.
   ignoreFailures = false
-  excludeFilter = rootProject.file('config/quality/findbugs/findbugs-filter.xml')
-  reportLevel = 'low' // low, medium, high 
+  excludeFilter = rootProject.file(Paths.get('config', 'quality', 'findbugs', 'findbugs-filter.xml'))
+  reportLevel = 'low' // low, medium, high
 }
 
 check.dependsOn 'findbugs'
 task findbugs(type: FindBugs,
     group: 'verification',
     description: 'findbugs checks for main and test java sourcesets of android projects',
-    dependsOn: ['compileDebugSources', 'compileReleaseSources']) {
+    dependsOn: 'assembleRelease' ) {
 
-  classes = fileTree("$project.buildDir/intermediates/classes/debug")
+  project.afterEvaluate {
+    def release = android.libraryVariants.find { it.name == 'release' }
+    classpath = files(android.bootClasspath) + release.javaCompile.classpath
+  }
+
+  classes = files(Paths.get("$buildDir", 'intermediates', 'classes', 'release'))
   source 'src'
   include '**/*.java'
   exclude '**/gen/**'
-  classpath = files(android.bootClasspath)
 
   reports {
     xml.enabled = false
@@ -27,7 +33,7 @@ task findbugs(type: FindBugs,
 }
 
 dependencies {
-  provided 'com.google.code.findbugs:annotations:3.0.0'
+  provided 'com.google.code.findbugs:annotations:3.0.1'
 }
 
 android {


### PR DESCRIPTION
to provide a complete classpath to findbugs we traverse project
dependencies, collecting all jars and aars from local `project` type
dependencies. we extract the `classes.jar` from aars and the put all the
jars on findbugs classpath.

This logic is shared with doclava, so I extracted the aar-unzipping into
a shared util. See `util/unzipAar.gradle` doc comment for usage
instructions.

closes #8