### PR TITLE
feat: allow project to configure custom source set for doclava javadoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ To ensure usability we follow these rules:
 * Major version changes must also provide a migration guide from the previous major version
 
 ## Versions <a name="versions"></a>
-### 1.2.0 (In Progress)
-* Documentation/doclava: add customization of javadoc classpath
+### 1.2.0 (2018-03-23)
+* Documentation/doclava: add customization of javadoc `source`
+* Documentation/doclava: add customization of javadoc `classpath`
 * Documentation/doclava: simplified javadoc classpath setup
 * buildSrc/SnapshotCheck: only apply to projcets in release version (according to semver)
 * Quality/Pmd: Exclude `AvoidFieldNameMatchingMethodName`, `JUnitTestContainsTooManyAsserts`, `CommentDefaultAccessModifier`, `MethodArgumentCouldBeFinal` rules

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -12,13 +12,17 @@ apply from: '../config/documentation/doclava/android.gradle'
 ## Example 2: Customizations
 
 ```groovy
-// needs to be defined BEFORE `apply` call 😢
+// needs to be defined BEFORE `apply` call to doclava script 😢
 project.ext.documentation = [
     javadocOverview: 'path/to/custom/overview.html',
     classpath: [ // anything that can be resolved by Project#files
         'path/to/additional/classpath', 
         configurations.javadocClasspath.files as List
-    ] // see https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#files-java.lang.Object...-
+    ], // see https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#files-java.lang.Object...-
+    source: { // closue that evaluates to a FileTree object, will be invoked after the project is evaluated, with no arguments
+        fileTree(project(':subproject-a').android.sourceSets.main.java.srcDirs[0]) + 
+        fileTree(project(':subproject-b').android.sourceSets.main.java.srcDirs[0])
+    }
 ]
 apply from: '../config/documentation/doclava/android.gradle'
 ```

--- a/documentation/doclava/android.gradle
+++ b/documentation/doclava/android.gradle
@@ -20,7 +20,6 @@ task generateDoclava(type: Javadoc, group: 'publishing') {
 
   failOnError = true
   title = null
-  source = android.sourceSets.main.java.srcDirs
 
   options {
     docletpath = configurations.doclava.files as List
@@ -45,6 +44,8 @@ task generateDoclava(type: Javadoc, group: 'publishing') {
   }
 
   project.afterEvaluate {
+    source = project.documentation.source ? project.documentation.source() : android.sourceSets.main.java.srcDirs
+
     destinationDir = new File(buildDir, 'javadocs')
 
     // Android


### PR DESCRIPTION
Rationale: we have projects that organize code in multiple projects but
still want to generate a combined javadoc for SDK users.

I intend to tag `1.2.0` after this is merged