### PR TITLE
feat(doc): make javadoc image assets project local

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,13 @@ To ensure usability we follow these rules:
 * Every version must describe the changes in [versions section](#versions)
 * Major version changes must also provide a migration guide from the previous major version
 
+## Migration 1.x.x -> 2.0.0
+If you use `docummentation/doclava` with image assets: move `$rootProject/images` to the project that includes the `documentation/doclava/android.gradle` script.
+
 ## Versions <a name="versions"></a>
+### 2.0.0 (2018-03-26)
+* Documentation/doclava: make image assets project local, i.e. not shared among subprojects.
+
 ### 1.2.0 (2018-03-23)
 * Documentation/doclava: add customization of javadoc `source`
 * Documentation/doclava: add customization of javadoc `classpath`

--- a/documentation/doclava/android.gradle
+++ b/documentation/doclava/android.gradle
@@ -11,7 +11,7 @@ import java.nio.file.Paths
 if(!project.hasProperty('documentation')) project.ext.documentation = [:]
 
 task copyImages(type: Copy) {
-  from Paths.get("$rootDir", "images")
+  from Paths.get("$projectDir", "images")
   into Paths.get("$buildDir", "javadocs", "reference", "images")
 }
 


### PR DESCRIPTION
this way sibling projects can create their own javadoc without the
sibling image assets.

This breaks existing javadoc/doclava configs, so we'll bump the version
to `2.0`.