### PR TITLE
💎 Update AGP, build and target SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ To ensure usability we follow these rules:
 If you use `docummentation/doclava` with image assets: move `$rootProject/images` to the project that includes the `documentation/doclava/android.gradle` script.
 
 ## Versions <a name="versions"></a>
+### HEAD
+* Update versions:
+  * AGP 3.1.0 (requires Gradle 4.4+).
+  * Targets (and builds with) SDK 27.
+
 ### 2.1.0 (2018-04-13)
 * Quality/jacoco: get rid of dependency of old unmaintained gradle plugin.
 

--- a/versions/versions.gradle
+++ b/versions/versions.gradle
@@ -16,10 +16,10 @@ ext.CONFIG.versions = [
             support     : '26.0.0',
             volley      : '1.0.0',
         ],
-        plugin: '3.0.1',
+        plugin: '3.1.0',
         sdk      : [
-            compile: 26,
-            target : 26,
+            compile: 27,
+            target : 27,
             min    : 15,
         ],
     ],


### PR DESCRIPTION
In order to validate behavior on API level 27, samples and QA app should target 27.
Also updating build sdk and plugin versions, which are lagging behind a bit.