### PR TITLE
🐛 [Quality] Fix findbugs complaining about annotations not found

### DIFF
--- a/quality/findbugs/android.gradle
+++ b/quality/findbugs/android.gradle
@@ -35,6 +35,7 @@ task findbugs(type: FindBugs,
 
 dependencies {
   compileOnly 'com.google.code.findbugs:annotations:3.0.1'
+  compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
 android {


### PR DESCRIPTION
This fixes the recurring warning below that previously filled build logs:

```
warning: Cannot find annotation method 'value()' in type 'SuppressFBWarnings': class file for edu.umd.cs.findbugs.annotations.SuppressFBWarnings not found
```