### PR TITLE
quality(checkstyle): remove inconsistent rule & update code formatter

### DIFF
--- a/quality/checkstyle/checkstyle.xml
+++ b/quality/checkstyle/checkstyle.xml
@@ -220,9 +220,6 @@
             <message key="name.invalidPattern"
              value="Method name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        <module name="SingleLineJavadoc">
-            <property name="ignoreInlineTags" value="false"/>
-        </module>
         <module name="EmptyCatchBlock">
             <property name="exceptionVariableName" value="expected"/>
         </module>

--- a/quality/checkstyle/java.gradle
+++ b/quality/checkstyle/java.gradle
@@ -16,7 +16,7 @@ configurations {
 }
 
 dependencies {
-  reformat 'com.google.googlejavaformat:google-java-format:1.5'
+  reformat 'com.google.googlejavaformat:google-java-format:1.6'
 }
 
 task reformatJavaSources(


### PR DESCRIPTION
Removes `SingleLineJavadoc` to accept google formatted code.
The google code formatter generates single line javadoc comments but the
google code style checkstyle config complains about them. in order to
use both the code formatter and still get warnings about style
problems (e.g. missing javadoc or variable names) I suggest we deviate
from the checkstlye ruleset provided by google to actually match their
formatter.

The code formatter was generating annotation indentation that violates
the google code style, which was fixed in 1.6 see google/google-java-format#159
and google/google-java-format@a268700