### PR TITLE
🔺 Raise target SDK to 28

### DIFF
--- a/versions/versions.gradle
+++ b/versions/versions.gradle
@@ -19,7 +19,7 @@ ext.CONFIG.versions = [
         plugin: '3.1.0',
         sdk      : [
             compile: 28,
-            target : 27,
+            target : 28,
             min    : 15,
         ],
     ],


### PR DESCRIPTION
This disables compatibility mode in Android Pie. Projects updating to this commit should review the various [behavioral changes](https://developer.android.com/about/versions/pie/android-9.0-changes-28) and fix their code accordingly.