### PR TITLE
Update Volley to v1.1.1

### DIFF
--- a/versions/versions.gradle
+++ b/versions/versions.gradle
@@ -14,7 +14,7 @@ ext.CONFIG.versions = [
         libraries: [
             playServices: '11.0.4',
             support     : '26.0.0',
-            volley      : '1.0.0',
+            volley      : '1.1.1',
         ],
         plugin: '3.1.0',
         sdk      : [


### PR DESCRIPTION
Volley 1.0.0 depends on Apache HTTP, however API 28 removed it as a dependency in the bootclasspath. Volley 1.1.0 makes Apache HTTP an optional dependency.