### PR TITLE
fix: (Doclava) Apply docletpath after project evaluate

### DIFF
--- a/documentation/doclava/android.gradle
+++ b/documentation/doclava/android.gradle
@@ -22,7 +22,9 @@ task generateDoclava(type: Javadoc, group: 'publishing') {
   title = null
 
   options {
-    docletpath = configurations.doclava.files as List
+    project.afterEvaluate {
+      docletpath = configurations.doclava.files as List
+    }
     doclet "com.google.doclava.Doclava"
     memberLevel = JavadocMemberLevel.PROTECTED
 

--- a/versions/versions.gradle
+++ b/versions/versions.gradle
@@ -16,7 +16,7 @@ ext.CONFIG.versions = [
             support     : '26.0.0',
             volley      : '1.1.1',
         ],
-        plugin: '3.1.0',
+        plugin: '3.2.1',
         sdk      : [
             compile: 28,
             target : 28,


### PR DESCRIPTION
Calling 'Configuration#files' resolves the configuration. This can cause issues with some gradle plugins such as 'kotlin-androidd' because it depends on the configurations not being resolved yet. Moving this call to 'Project#afterEvaluate' avoids these issues.