### PR TITLE
Move PMD task before running tests to see results quicker.

### DIFF
--- a/quality/pmd/android.gradle
+++ b/quality/pmd/android.gradle
@@ -10,7 +10,7 @@ pmd {
   toolVersion = '5.8.1' // see https://github.com/pmd/pmd/releases
 }
 
-check.dependsOn 'pmd'
+assemble.dependsOn 'pmd'
 task pmd(type: Pmd,
     group: 'verification',
     description: 'pmd checks for main and test java sourcesets of android projects') {


### PR DESCRIPTION
PMD task is one of the last tasks when running './gradlew build`, so

It is very annoying when run `./gradlew build`, seeing all tests pass, which takes a long time, then PMD task fails.

Signed-off-by: Wang, Paul <paul.wang@rakuten.com>