### PR TITLE
jacoco: Change variant name to capitlized for executionData

### DIFF
--- a/quality/jacoco/android.gradle
+++ b/quality/jacoco/android.gradle
@@ -19,13 +19,14 @@ project.afterEvaluate {
 }
 
 def addJacocoTask(variant) {
-  logger.info("adding jacoco task for variant $variant.name")
+  def variantName = $variant.name.capitalize()
+  logger.info("adding jacoco task for variant $variantName")
 
   // see https://docs.gradle.org/current/dsl/org.gradle.testing.jacoco.tasks.JacocoReport.html
-  def jacocoTask = project.tasks.create("jacoco${variant.name.capitalize()}Report", JacocoReport)
-  jacocoTask.dependsOn("test${variant.name.capitalize()}UnitTest")
+  def jacocoTask = project.tasks.create("jacoco${variantName}Report", JacocoReport)
+  jacocoTask.dependsOn("test${variantName}UnitTest")
   jacocoTask.group = 'verification'
-  jacocoTask.description = "Generate Jacoco Report for variant $variant.name"
+  jacocoTask.description = "Generate Jacoco Report for variant $variantName"
 
   jacocoTask.reports {
     csv.enabled false
@@ -50,7 +51,7 @@ def addJacocoTask(variant) {
 
   if(project.plugins.hasPlugin("kotlin-android")) {
     sourceDirectories.from(files(variant.sourceSets.kotlin.srcDirs.flatten()))
-    def kotlinTask = tasks.getByName("compile${variant.name.capitalize()}Kotlin")
+    def kotlinTask = tasks.getByName("compile${variantName}Kotlin")
     if(kotlinTask) {
       classDirectories += fileTree(dir: kotlinTask.destinationDir, excludes: excludedFiles)
     }
@@ -58,6 +59,6 @@ def addJacocoTask(variant) {
 
   jacocoTask.sourceDirectories = sourceDirectories
   jacocoTask.classDirectories = classDirectories
-  jacocoTask.executionData = files("${buildDir}/jacoco/test${variant.name}UnitTest.exec")
+  jacocoTask.executionData = files("${buildDir}/jacoco/test${variantName}UnitTest.exec")
   jacocoTask
 }


### PR DESCRIPTION
Jacoco was failing to find the executionData on some systems (Linux) because the variant name wasn't capitalized correctly. This particularly causes problems on CircleCi because builds run in Linux containers.