### PR TITLE
Update detekt to the gradle plugin

### DIFF
--- a/quality/README.md
+++ b/quality/README.md
@@ -83,7 +83,20 @@ tasks.withType(JavaCompile) {
 Static code analysis for Kotlin.
 
 ```groovy
-// android plugin
-apply from: '../config/quality/detekt/android.gradle'
+// root script
+buildscript {
+  apply from: "config/index.gradle"
+}
+plugins {
+  id 'io.gitlab.arturbosch.detekt' version '1.0.0-RC14'
+}
+
+// sub project
+apply from: "../config/quality/detekt/android.gradle"
+dependencies {
+  // Add to enable the KtLint rules
+  detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:1.0.0-RC14"
+}
 ```
-To test it, use the task : `./gradlew detekt`
+
+To test it, use the task : `./gradlew detekt`. See [the detekt docs](https://arturbosch.github.io/detekt/groovydsl.html) for additional configuration options.

--- a/quality/detekt/android.gradle
+++ b/quality/detekt/android.gradle
@@ -1,27 +1,12 @@
-// see https://github.com/arturbosch/detekt#using-detekt-in-custom-gradle-projects
-repositories {
-    jcenter()
-}
+apply plugin: 'io.gitlab.arturbosch.detekt'
 
-configurations {
-    detekt
-}
-
-task detekt(
-        type: JavaExec,
-        group: 'verification',
-        description: 'checkstyle for main kotlin sourcesets of android projects\'') {
-    main = "io.gitlab.arturbosch.detekt.cli.Main"
-    classpath = configurations.detekt
-    def inputPath = "$projectDir"
-    def configPath = files(rootProject.file('config/quality/detekt/detekt-config.yml')).asPath
-    def outputPath = "${buildDir}/reports/detekt"
-    def params = [ '-i', inputPath, '-c', configPath, '-o', outputPath]
-    args(params)
+detekt {
+    input = files(projectDir)
+    config = rootProject.files('config/quality/detekt/detekt-config.yml')
+    reports {
+        xml { destination = file("${buildDir}/reports/detekt/detekt.xml") }
+        html { destination = file("${buildDir}/reports/detekt/detekt.html") }
+    }
 }
 
 check.dependsOn detekt
-
-dependencies {
-    detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.0.0.RC6-4'
-}

--- a/quality/detekt/detekt-config.yml
+++ b/quality/detekt/detekt-config.yml
@@ -9,15 +9,21 @@ test-pattern: # Configure exclusions for test sources
     - '.*Spec.kt'
   exclude-rule-sets:
     - 'comments'
+    - 'naming'
   exclude-rules:
     - 'NamingRules'
     - 'WildcardImport'
+    - 'NoWildcardImports'
     - 'MagicNumber'
     - 'MaxLineLength'
     - 'LateinitUsage'
     - 'StringLiteralDuplication'
+    - 'ForEachOnRange'
     - 'SpreadOperator'
     - 'TooManyFunctions'
+    - 'InstanceOfCheckForException'
+    - 'TooGenericExceptionCaught'
+    - 'ClassNaming'
 
 build:
   maxIssues: 5
@@ -45,13 +51,6 @@ console-reports:
   #  - 'FindingsReport'
   #  - 'BuildFailureReport'
 
-output-reports:
-  active: true
-  exclude:
-  #  - 'HtmlOutputReport'
-  #  - 'PlainOutputReport'
-  #  - 'XmlOutputReport'
-
 comments:
   active: true
   CommentOverPrivateFunction:
@@ -60,7 +59,7 @@ comments:
     active: false
   EndOfSentenceFormat:
     active: true
-    endOfSentenceFormat: ([.?!][ \t\n\r\f<])|([.?!]$)
+    endOfSentenceFormat: ([.?!][ \t\n\r\f<])|([.?!:]$)
   UndocumentedPublicClass:
     active: true
     searchInNestedClass: true
@@ -83,6 +82,7 @@ complexity:
     active: true
     threshold: 10
     ignoreSingleWhenExpression: false
+    ignoreSimpleWhenEntries: false
   LabeledExpression:
     active: true
   LargeClass:
@@ -114,6 +114,9 @@ complexity:
     thresholdInInterfaces: 11
     thresholdInObjects: 11
     thresholdInEnums: 11
+    ignoreDeprecated: false
+    ignorePrivate: false
+    ignoreOverridden: false
 
 empty-blocks:
   active: true
@@ -165,6 +168,7 @@ exceptions:
     active: true
   SwallowedException:
     active: true
+    ignoredExceptionTypes: 'InterruptedException,NumberFormatException,ParseException,MalformedURLException'
   ThrowingExceptionFromFinally:
     active: true
   ThrowingExceptionInMain:
@@ -185,6 +189,7 @@ exceptions:
      - IndexOutOfBoundsException
      - RuntimeException
      - Throwable
+    allowedExceptionNameRegex: "^(_|(ignore|expected).*)"
   TooGenericExceptionThrown:
     active: true
     exceptionNames:
@@ -193,11 +198,111 @@ exceptions:
      - Throwable
      - RuntimeException
 
+formatting:
+  active: true
+  android: false
+  autoCorrect: true
+  ChainWrapping:
+    active: true
+    autoCorrect: true
+  CommentSpacing:
+    active: true
+    autoCorrect: true
+  Filename:
+    active: true
+  FinalNewline:
+    active: true
+    autoCorrect: true
+  ImportOrdering:
+    active: false
+  Indentation:
+    active: true
+    autoCorrect: true
+    indentSize: 4
+    continuationIndentSize: 4
+  MaximumLineLength:
+    active: true
+    maxLineLength: 120
+  ModifierOrdering:
+    active: true
+    autoCorrect: true
+  NoBlankLineBeforeRbrace:
+    active: true
+    autoCorrect: true
+  NoConsecutiveBlankLines:
+    active: true
+    autoCorrect: true
+  NoEmptyClassBody:
+    active: true
+    autoCorrect: true
+  NoItParamInMultilineLambda:
+    active: false
+  NoLineBreakAfterElse:
+    active: true
+    autoCorrect: true
+  NoLineBreakBeforeAssignment:
+    active: true
+    autoCorrect: true
+  NoMultipleSpaces:
+    active: true
+    autoCorrect: true
+  NoSemicolons:
+    active: true
+    autoCorrect: true
+  NoTrailingSpaces:
+    active: true
+    autoCorrect: true
+  NoUnitReturn:
+    active: true
+    autoCorrect: true
+  NoUnusedImports:
+    active: true
+    autoCorrect: true
+  NoWildcardImports:
+    active: true
+    autoCorrect: true
+  PackageName:
+    active: true
+    autoCorrect: true
+  ParameterListWrapping:
+    active: true
+    autoCorrect: true
+    indentSize: 4
+  SpacingAroundColon:
+    active: true
+    autoCorrect: true
+  SpacingAroundComma:
+    active: true
+    autoCorrect: true
+  SpacingAroundCurly:
+    active: true
+    autoCorrect: true
+  SpacingAroundKeyword:
+    active: true
+    autoCorrect: true
+  SpacingAroundOperators:
+    active: true
+    autoCorrect: true
+  SpacingAroundParens:
+    active: true
+    autoCorrect: true
+  SpacingAroundRangeOperator:
+    active: true
+    autoCorrect: true
+  StringTemplate:
+    active: true
+    autoCorrect: true
+
 naming:
   active: true
   ClassNaming:
     active: true
     classPattern: '[A-Z$][a-zA-Z0-9$]*'
+  ConstructorParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    privateParameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
   EnumNaming:
     active: true
     enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
@@ -214,6 +319,15 @@ naming:
     active: true
     functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
     excludeClassPattern: '$^'
+    ignoreOverridden: true
+  FunctionParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverriddenFunctions: true
+  InvalidPackageDeclaration:
+    active: false
+    rootPackage: ''
   MatchingDeclarationName:
     active: true
   MemberNameEqualsClassName:
@@ -221,16 +335,17 @@ naming:
     ignoreOverriddenFunction: true
   ObjectPropertyNaming:
     active: true
-    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     constantPattern: '[A-Za-z][_A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
     packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
   TopLevelPropertyNaming:
     active: true
     constantPattern: '[A-Z][_A-Z0-9]*'
-    propertyPattern: '[a-z][A-Za-z\d]*'
-    privatePropertyPattern: '(_)?[a-z][A-Za-z0-9]*'
+    propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
   VariableMaxLength:
     active: true
     maximumVariableNameLength: 64
@@ -242,9 +357,12 @@ naming:
     variablePattern: '[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
+    ignoreOverridden: true
 
 performance:
   active: true
+  ArrayPrimitive:
+    active: false
   ForEachOnRange:
     active: true
   SpreadOperator:
@@ -272,6 +390,8 @@ potential-bugs:
     active: false
     excludeAnnotatedProperties: ""
     ignoreOnClassesPattern: ""
+  MissingWhenCase:
+    active: false
   UnconditionalJumpStatementInLoop:
     active: true
   UnreachableCode:
@@ -292,16 +412,26 @@ style:
   DataClassContainsFunctions:
     active: true
     conversionFunctionPrefix: 'to'
+  DataClassShouldBeImmutable:
+    active: false
   EqualsNullCall:
     active: true
+  EqualsOnSignatureLine:
+    active: false
+  ExplicitItLambdaParameter:
+    active: false
   ExpressionBodySyntax:
     active: true
+    includeLineWrapping: false
   ForbiddenComment:
     active: true
     values: 'TODO:,FIXME:,STOPSHIP:'
   ForbiddenImport:
     active: false
     imports: ''
+  ForbiddenVoid:
+    active: false
+    ignoreOverridden: false
   FunctionOnlyReturningConstant:
     active: true
     ignoreOverridableFunction: true
@@ -319,11 +449,14 @@ style:
     ignoreAnnotation: false
     ignoreNamedArgument: true
     ignoreEnums: false
+    ignoreRanges: false
+  MandatoryBracesIfStatements:
+    active: false
   MaxLineLength:
     active: true
-    maxLineLength: 150
-    excludePackageStatements: false
-    excludeImportStatements: false
+    maxLineLength: 120
+    excludePackageStatements: true
+    excludeImportStatements: true
     excludeCommentStatements: false
   MayBeConst:
     active: true
@@ -341,6 +474,8 @@ style:
     active: false
   OptionalWhenBraces:
     active: true
+  PreferToOverPairSyntax:
+    active: false
   ProtectedMemberInFinalClass:
     active: true
   RedundantVisibilityModifierRule:
@@ -349,6 +484,8 @@ style:
     active: true
     max: 2
     excludedFunctions: "equals"
+    excludeLabeled: false
+    excludeReturnFromLambda: true
   SafeCast:
     active: true
   SerialVersionUIDInSerializableClass:
@@ -360,24 +497,42 @@ style:
     max: 2
   TrailingWhitespace:
     active: true
+  UnderscoresInNumericLiterals:
+    active: false
+    acceptableDecimalLength: 5
   UnnecessaryAbstractClass:
     active: true
+    excludeAnnotatedClasses: "dagger.Module"
+  UnnecessaryApply:
+    active: false
   UnnecessaryInheritance:
     active: true
+  UnnecessaryLet:
+    active: false
   UnnecessaryParentheses:
     active: false
   UntilInsteadOfRangeTo:
     active: false
   UnusedImports:
     active: true
+  UnusedPrivateClass:
+    active: false
   UnusedPrivateMember:
     active: false
-    allowedNames: "(_|ignored|expected)"
+    allowedNames: "(_|ignored|expected|serialVersionUID)"
+  UseCheckOrError:
+    active: false
   UseDataClass:
     active: true
     excludeAnnotatedClasses: ""
-  UtilityClassWithPublicConstructor:
-    active: true
-  WildcardImport:
+  UseRequire:
     active: false
+  UselessCallOnNotNull:
+    active: false
+  UtilityClassWithPublicConstructor:
+    active: false
+  VarCouldBeVal:
+    active: false
+  WildcardImport:
+    active: true
     excludeImports: 'java.util.*,kotlinx.android.synthetic.*'


### PR DESCRIPTION
Detekt was previously using the cli version, but there is now a Gradle plugin available. There have also been some rules added and changed, so the rule config has been slightly updated. Detekt also now has a ruleset that applies all of the formatting rules from KtLint, so I have also added instructions for this to the readme.
