### PR TITLE
fix: (publish) Make env variable for bintray package name

### DIFF
--- a/publish/README.md
+++ b/publish/README.md
@@ -12,7 +12,8 @@ The following environment variables need to be set.
 # If publishing to Bintray
 BINTRAY_USER=username
 BINTRAY_KEY=password
-BINTRAY_REPO=your_repo_name
+BINTRAY_REPO=your_bintray_repo_name
+BINTRAY_PACKAGE_NAME=your_bintray_package_name
 
 # If publishing to Artifactory (this example uses the Jfrog OSS Snapshot repo)
 ARTIFACTORY_USER=username

--- a/publish/bintray.gradle
+++ b/publish/bintray.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.jfrog.bintray'
 def user = System.getenv('BINTRAY_USER')
 def key = System.getenv('BINTRAY_KEY')
 def repo = System.getenv('BINTRAY_REPO')
+def pkgName = System.getenv('BINTRAY_PACKAGE_NAME')
 
 bintray {
   it.user = user
@@ -10,7 +11,7 @@ bintray {
   publications = publishing.publications.collect{ it.name }
   pkg {
     it.repo = repo
-    name = 'android-remote-config'
+    name = pkgName
     licenses = ['MIT']
     vcsUrl = project.scmUrl
     version {


### PR DESCRIPTION
I accidentally left android-remote-config in for the package name, so this would cause packages to get published there instead of the correct package