### PR TITLE
fix: add nullaway to `errorprone` configuration

### DIFF
--- a/quality/errorprone/android.gradle
+++ b/quality/errorprone/android.gradle
@@ -6,6 +6,7 @@ dependencies {
     errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
   }
   errorprone 'com.google.errorprone:error_prone_core:2.3.2'
+  errorprone 'com.uber.nullaway:nullaway:0.6.5' # see https://github.com/uber/NullAway/issues/247#issuecomment-476015654
   annotationProcessor 'com.uber.nullaway:nullaway:0.6.5'
   testAnnotationProcessor 'com.uber.nullaway:nullaway:0.6.5'
 }


### PR DESCRIPTION
I ran into the following problem:
```
> Task :some-sdk:compileDebugAndroidTestJavaWithJavac FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':some-sdk:compileDebugAndroidTestJavaWithJavac'.
> NullAway is not a valid checker name
```
and found that other users experienced the same issue -> https://github.com/uber/NullAway/issues/247
this is maybe not the minimal solution, but solved the problem for me.