### PR TITLE
Update android gradle plugin to v3.6.2

### DIFF
--- a/versions/versions.gradle
+++ b/versions/versions.gradle
@@ -16,7 +16,7 @@ ext.CONFIG.versions = [
             support     : '26.0.0',
             volley      : '1.1.1',
         ],
-        plugin: '3.3.1',
+        plugin: '3.6.2',
         sdk      : [
             compile: 29,
             target : 29,


### PR DESCRIPTION
This version of AGP requires Gradle v5.6.4 or higher