### PR TITLE
(documentation) Add failOnError parameter for DocLava

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -25,7 +25,8 @@ project.ext.documentation = [
     source: { // closue that evaluates to a FileTree object, will be invoked after the project is evaluated, with no arguments
         fileTree(project(':subproject-a').android.sourceSets.main.java.srcDirs[0]) + 
         fileTree(project(':subproject-b').android.sourceSets.main.java.srcDirs[0])
-    }
+    },
+    failOnError: true
 ]
 apply from: '../config/documentation/doclava/android.gradle'
 ```

--- a/documentation/doclava/android.gradle
+++ b/documentation/doclava/android.gradle
@@ -21,7 +21,7 @@ task generateDoclava(type: Javadoc, group: 'publishing') {
     }
   }
 
-  failOnError = true
+  failOnError = project.documentation.failOnError != null ? project.documentation.failOnError : true
   title = null
 
   options {


### PR DESCRIPTION
This is so failOnError can be disabled. Normally it should not be disabled, but sometimes it needs to be temporarily disabled due to conflicts with dependencies.