### PR TITLE
Maven publishing plugin updates - also bump to v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This repository contains common configuration to be used across our Android libraries. The advantage of sharing these configurations in mainly consistency of configuration among multiple libraries and reduction of boilerplate.
 
 ## Kickstart
-First add the subomudle to your project:
+First add the submodule to your project:
 
 ```sh
 $ cd my_project
@@ -52,14 +52,20 @@ To ensure usability we follow these rules:
 * Every version must describe the changes in [versions section](#versions)
 * Major version changes must also provide a migration guide from the previous major version
 
-## Migration 1.x.x -> 2.0.0
-If you use `docummentation/doclava` with image assets: move `$rootProject/images` to the project that includes the `documentation/doclava/android.gradle` script.
-
 ## Versions <a name="versions"></a>
 ### HEAD
 * Update versions:
-  * AGP 3.3.1 (requires Gradle 4.10.1+).
-  * Targets (and builds with) SDK 27.
+  * AGP 3.6.2 (requires Gradle 5.6.4+).
+  * Targets (and builds with) SDK 29.
+
+### 4.0.0 (2020-07-17)
+* **Breaking Change:** Remove `digital.wup.android-maven-publish` plugin as it is deprecated and AGP now has built-in support for the [maven-publish plugin](https://developer.android.com/studio/build/maven-publish-plugin). Due to this change, you now must configure your publications within a the `afterEvaluate` phase. See the [publishing readme](publish/README.md] for more details. You should also remove `digital.wup.android-maven-publish` from your dependencies.
+* Added support for [KDoc generation](documentation/README.md] using dokka.
+* Update target/compile SDK to 29 and update Min SDK to 21.
+* Update Android Gradle Plugin to 3.6.2. You must now update your Gradle version to 5.6.4+.
+* Add support for publishing to [Bintray or Artifactory](publish/README.md).
+* Fixed an issue with documentation generation where images sometimes weren't copied to the documentation folder.
+* Add `property` closure to `CONFIG`. This can be used to return a value that has been set as either an environment variable or gradle property. Use like this: `CONFIG.property('PROPERTY_NAME')`.
 
 ### 3.0.0 (2018-04-13)
 * Remove Kotlin check style tool, `Ktlint`, to replace it by `Detekt`.

--- a/index.gradle
+++ b/index.gradle
@@ -1,6 +1,9 @@
 buildscript {
   ext.CONFIG = [
       configDir: getSourceFile().parent,
+      property: { key ->
+        return System.getenv(key) ?: (project.hasProperty(key) ? project."$key" : null)
+      }
   ]
 }
 

--- a/publish/README.md
+++ b/publish/README.md
@@ -91,7 +91,8 @@ afterEvaluate {
           description:  'different description',
           licenseName:  'different license',
           licenseUrl:   'https://www.example.com',
-          scmUrl:       'https://www.example.com/repo.git'
+          scmUrl:       'https://www.example.com/repo.git',
+          excludeSourceJar: false // By default, a Jar containing the module's source in added to artifacts - set to true to exlcude the Jar
         ))
       }
     }

--- a/publish/android.gradle
+++ b/publish/android.gradle
@@ -34,7 +34,9 @@ ext.androidArtifact = { Map config ->
     groupId config.get('groupId') ?: project.group
     version config.get('version') ?: project.version
 
-    artifact sourceJar
+    if (!config.get('excludeSourceJar')) {
+      artifact sourceJar
+    }
     if (javaDocTask) {
       artifact javaDocJar
     }

--- a/publish/android.gradle
+++ b/publish/android.gradle
@@ -1,6 +1,6 @@
 import java.nio.file.Paths
 
-apply plugin: 'digital.wup.android-maven-publish'
+apply plugin: 'maven-publish'
 
 task sourceJar(type: Jar) {
   from android.sourceSets.main.java.srcDirs
@@ -29,8 +29,10 @@ ext.androidArtifact = { Map config ->
   return {
     config = config ?: [:]
 
-    from config.get('from') ?: components.android
+    from config.get('from') ?: components.release
     artifactId config.get('artifactId') ?: project.name
+    groupId config.get('groupId') ?: project.group
+    version config.get('version') ?: project.version
 
     artifact sourceJar
     if (javaDocTask) {
@@ -45,8 +47,6 @@ ext.androidArtifact = { Map config ->
 
     pom {
       name = config.get('name') ?: project.name
-      groupId config.get('groupId') ?: project.group
-      version config.get('version') ?: project.version
       description = config.get('description') ?: project.description
       url = config.get('url') ?: project.url
       licenses {


### PR DESCRIPTION
- publish: Replace publishing plugin with AGPs built-in maven-publish
  - Remove the requirement for a dependency on digital.wup.android-maven-publish as this plugin has been deprecated and AGP now has built-in support for maven publishing. This means that the 'publications' block must now be declared within a 'afterEvaluate' block.
- publish: Add 'excludeSourceJar' config option
  - Sometimes the sources Jar should not be published - such as when the published AAR is minified/obfuscated
- Add 'property' closure to CONIFG
  - This can be used to return a value that has been set as either an environment variable or gradle property. Use like this: 'CONFIG.property('PROPERTY_NAME')'
- Update readme for v4.0.0