### PR TITLE
Add CircleCI Orb configuration for android-sdk and app-center

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ By default only [versions](versions/README.md) is added to the project. You can 
 * [BuildSrc](buildSrc/README.md)
 * [Documentation](documentation/README.md)
 * [Publish](publish/README.md)
+* [CircleCI Orbs](circleci/README.md)
 
 ## Versioning Contract
 This configuration's versions follow [semantic versioning](https://semver.org/). We align all libraries that we bundle together on the same major version of this configuration. To clarify the semantics in the context of shared configurations here are a few examples of what are breaking changes (major version change), backwards compatible improvements (minor version change) and bug fixes (patch level):

--- a/circleci/README.md
+++ b/circleci/README.md
@@ -1,0 +1,38 @@
+# CircleCI Jobs
+
+These are [CircleCI Orbs](https://circleci.com/docs/2.0/orb-intro/) which can be used for building and publishing Android SDK projects on CircleCI. These Orbs are published to the [CircleCI Orb Registry](https://circleci.com/orbs/registry/), so you do not need to use the config files in this repo (they are here only as the source for the published Orbs).
+
+We have two different Orbs which are published. See the each Orb's Readme for instructions on how to use:
+- [android-sdk](android-sdk/README.md): Used to build and publish Android SDK projects
+- [app-center](app-center/README.md): Used to publish a binary to App center. Can be used with any type of project supported by App Center, i.e. Android, iOS, etc.
+
+## How to publish Orbs
+
+These orbs are already published to the `rakutentech` organization, so these instructions are only relevant to users who wish to publish Orbs by themselves.
+
+See [CircleCI docs](https://github.com/CircleCI-Public/config-preview-sdk/blob/v2.1/docs/orbs-authoring.md) for more info. In order to publish the Orbs, you must have installed the [CircleCI CLI](https://circleci.com/docs/2.0/local-cli/). On a Mac, you can install it with `brew install circleci`.
+
+Also, you must have a Github account which belongs to the [rakutentech organization](https://github.com/rakutentech) and a CircleCI token created [here](https://circleci.com/account/api).
+
+First, validate the orb:
+
+```bash
+circleci orb validate ./android-sdk/config.yml --token TOKEN
+```
+
+Next, if validation passed then you can publish the orb as a development version for testing:
+
+```bash
+circleci orb publish ./android-sdk/config.yml rakutentech/android-sdk@dev:0.1.0 --token TOKEN
+```
+
+Finally, you can promote the development orb to a production orb:
+
+```bash
+circleci orb publish promote rakutentech/android-sdk@dev:0.1.0 minor --token TOKEN
+```
+
+## Resources
+- [Orbs Intro](https://circleci.com/docs/2.0/orb-intro/)
+- [Orbs Docs](https://github.com/CircleCI-Public/config-preview-sdk/blob/v2.1/docs/README.md)
+- [Orbs Registry](https://circleci.com/orbs/registry/)

--- a/circleci/android-sdk/README.md
+++ b/circleci/android-sdk/README.md
@@ -1,0 +1,100 @@
+# android-sdk Orb
+
+See the [android-sdk Orb page](https://circleci.com/orbs/registry/orb/rakutentech/android-sdk) for details on the jobs included by this Orb.
+
+## Basic Setup
+
+This basic setup will do the following:
+- Checkout the Git repo and initialize any Git submodules.
+- Run the `build` job.
+    - Run Gradle's `check` and `assemble` commands.
+    - Upload coverage to (Code Cov)(https://codecov.io).
+    - Store artifacts: `reports`, `test-results`, `aar`, and `apk`
+    - Persists to workspace: the `build` folder for `sdk-path` and the `apk` folder for the `sample-app-path`.
+- If this is a release (a Git tag that starts with `v`), then pause for user verification.
+- If verified by user, then run the `publish` job.
+    - Run Gradle's `publish` command.
+
+```yml
+version: 2.1
+
+orbs:
+  android-sdk: rakutentech/android-sdk:{CURRENT_VERSION}
+
+workflows:
+  version: 2.1
+  build-and-release:
+    jobs:
+      - android-sdk/build:
+          gradle-cache-key: gradle-{{ checksum "build.gradle" }}-{{ checksum "YOUR_SDK_PATH/build.gradle" }}
+          maven-cache-key: maven-{{ checksum "SDK_PATH/src/test/AndroidManifest.xml" }}
+          sdk-path: YOUR_SDK_PATH
+          sample-app-path: YOUR_SAMPLE_APP_PATH
+          # You can optionally define `pre-steps` which will run before any other steps in the job.
+          pre-steps:
+            - run:
+                command: echo "Pre steps"
+          # You can optionally define `after-prepare-steps` commands which will run after the project has been checked out and the Gradle dependencies have been downloaded
+          after-prepare-steps:
+            - run:
+                command: echo "After prepare"
+          # You can optionally define `post-steps` which will run after all other steps in the job have completed.
+          post-steps:
+            - run:
+                command: echo "Post steps"
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only: /.*/
+
+      - release-verification:
+          type: approval
+          requires:
+            - android-sdk/build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+
+      - android-sdk/publish:
+          requires:
+            - release-verification
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+```
+
+## Advanced
+
+### Building Release APK using a release keystore
+
+You may want to build and publish an APK which uses your release keystore. In that case, you don't want to commit the keystore to your repository due to security reasons.
+
+Instead, you can convert the keystore file to a base64 string, then add that string to CircleCI as an environment variable (in the project settings).
+
+First, convert the keystore file to a base64 string:
+
+```bash
+openssl base64 -A -in release-keystore.jks
+```
+
+Copy the output of this and set it as an environment variable `RELEASE_KEYSTORE_BASE64` in your CircleCI project settings.
+
+Finally, when running your job you can convert this base64 string back into a file. If you are using the `android-sdk` orb, then you can add this to the pre-steps section.
+
+```yml
+- run: |
+    if [[ $RELEASE_KEYSTORE_BASE64 != "" ]]; then
+        base64 -d \<<< $RELEASE_KEYSTORE_BASE64 > ./release-keystore.jks
+    fi
+```
+
+## Versions
+
+### 0.1.0 (2020-07-28)
+
+- Initial release.

--- a/circleci/android-sdk/config.yml
+++ b/circleci/android-sdk/config.yml
@@ -1,0 +1,104 @@
+version: 2.1
+
+android-docker-image: &android-docker-image circleci/android:api-29
+
+jobs: 
+  build:
+    description: Runs all checks (unit tests, lint, etc.) and assembles all binaries including the SDK `.aar` files and the Sample App `.apk` files. Build artifacts will be persisted to the Workspace, so they will be available for use in other jobs. The SDK artifacts in the `{sdk-path}/build/` folder will be persisted and the Sample App APKs will be persisted to the `apk' folder. This job assumes that you are using the android-buildconfig (https://github.com/rakutentech/android-buildconfig) and have setup your project to use axion-release-plugin (https://github.com/allegro/axion-release-plugin) for versioning. It also assumes that your Github repo is setup to use Code Cov (https://codecov.io) and it will upload coverage there.
+    parameters:
+      gradle-cache-key:
+        description: Key used by CircleCI for saving the Gradle cache ('~/.gradle'). If the key changes, then CircleCI will not use the saved cache. This value should be based on a checksum of all 'build.gradle' files in your project.
+        default: >- 
+          gradle-
+          {{ checksum "build.gradle" }}
+          {{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+        type: string
+      maven-cache-key:
+        description: Key used by CircleCI for saving the Maven cache ('~/.m2'). If the key changes, then CircleCI will not use the saved cache. The Maven cache is typically only used by Robolectric, so this value should be based on a checksum of the file which contains your Robolectric settings.
+        default: maven
+        type: string
+      sdk-path:
+        description: Path to the SDK module of your project, relative to the root directory.
+        type: string
+      sample-app-path:
+        description: Path to the Sample App module of your project, relative to the root directory.
+        type: string
+      after-prepare-steps:
+        description: Steps to run after the built-in preparation steps have run (checkout, git submodule preparation, and downloading dependencies).
+        type: steps
+        default: []
+    docker:
+      - image: *android-docker-image
+    working_directory: ~/code
+    environment:
+      # from https://discuss.circleci.com/t/circle-ci-v2-and-android-memory-issues/11207
+      JVM_OPTS: "-Xmx1024m -XX:+PrintFlagsFinal -XX:+PrintGCDetails"
+      _JAVA_OPTIONS: "-Xmx1024m"
+      GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false"
+    steps:
+      - checkout
+      - run: git submodule update --init
+      - restore_cache:
+          key: <<parameters.gradle-cache-key>>
+      - run:
+          name: Download Dependencies
+          command: ./gradlew androidDependencies
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: <<parameters.gradle-cache-key>>
+      - restore_cache:
+          ## Robolectric uses maven to download sources, so we must use a different cache for maven
+          key: <<parameters.maven-cache-key>>
+      - steps: <<parameters.after-prepare-steps>>
+      - run:
+          name: Run Check
+          command: ./gradlew check
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: <<parameters.maven-cache-key>>
+      - run:
+          name: Assemble
+          command: ./gradlew assemble
+      - run:
+          name: Current Version
+          command: ./gradlew currentVersion
+      - run:
+          name: Upload Code Coverage
+          command: bash <(curl -s https://codecov.io/bash)
+      - store_artifacts:
+          path: <<parameters.sdk-path>>/build/reports
+          destination: reports/
+      - store_test_results:
+          path: <<parameters.sdk-path>>/build/test-results
+      - store_artifacts:
+          path: <<parameters.sdk-path>>/build/outputs/aar
+          destination: aar/
+      - persist_to_workspace:
+          root: <<parameters.sample-app-path>>/build/outputs
+          paths:
+            - apk/
+      - persist_to_workspace:
+          root: ~/code
+          paths:
+            - <<parameters.sdk-path>>/build/
+
+  publish:
+    description: Publish SDK (run Gradle's 'publish' command). Previously persisted workspace will be attached at `./`.
+    docker:
+      - image: *android-docker-image
+    working_directory: ~/code
+    environment:
+      JVM_OPTS: "-Xmx3200m"
+    steps:
+      - checkout
+      - run: git submodule update --init
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Current Version
+          command: ./gradlew cV
+      - run:
+          name: Publish Artifacts
+          command: ./gradlew publish

--- a/circleci/app-center/README.md
+++ b/circleci/app-center/README.md
@@ -1,0 +1,59 @@
+# app-center Orb
+
+See the [app-center Orb page](https://circleci.com/orbs/registry/orb/rakutentech/app-center) for details on the jobs included by this Orb.
+
+## Basic Setup
+
+This basic setup will do the following:
+- Publish the provided file to App Center.
+    - You can use this job multiple times to publish different binaries, but note that you must define a unique `name` for each job.
+
+```yml
+version: 2.1
+
+orbs:
+  app-center: rakutentech/app-center:{CURRENT_VERSION}
+
+workflows:
+  version: 2.1
+  build-and-release:
+    jobs:
+      # Run your build job
+      - android-sdk/build:
+
+      # Publish STG build to Testers
+      - app-center/publish:
+          name: publish-test-app-stg    
+          group: Testers
+          file: apk/staging/testapp-staging.apk
+          app: $APP_CENTER_APP_NAME
+          token: $APP_CENTER_TOKEN
+          notes: $CIRCLE_BUILD_URL
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+
+      # Publish production build to a different group
+      - app-center/publish:
+          name: publish-test-app-prod
+          group: Production
+          file: apk/release/testapp-release.apk
+          app: $APP_CENTER_APP_NAME
+          token: $APP_CENTER_TOKEN
+          notes: Production build for $CIRCLE_TAG
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+```
+
+## Versions
+
+### 0.1.0 (2020-07-28)
+
+- Initial release.

--- a/circleci/app-center/config.yml
+++ b/circleci/app-center/config.yml
@@ -1,0 +1,41 @@
+version: 2.1  
+  
+jobs:
+  publish:
+    description: Publish a file to App Center. This job expects that you have persisted a workspace in a previous job and it will attach the workspace at `./`.
+    parameters:
+      group:
+        description: Group name from App Center.
+        type: string
+      file:
+        description: Path of file to publish. This can be a build artifact from a previous step which was persisted to the workspace.
+        type: string
+      app:
+        description: App name from App Center.
+        type: string
+      token:
+        description: Token for publishing to App Center.
+        type: string
+      notes:
+        description: Notes that will be attached to the App Center release.
+        type: string
+        default: ""
+    docker:
+      - image: circleci/node
+    working_directory: ~/code
+    steps:
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Install App Center CLI
+          command: npm init --yes && npm install appcenter-cli
+      - run:
+          name: Upload and distribute release to App Center
+          command: >
+            npx appcenter distribute release
+            --group <<parameters.group>>
+            --file <<parameters.file>>
+            --app <<parameters.app>>
+            --release-notes <<parameters.notes>>
+            --token <<parameters.token>>
+            --quiet


### PR DESCRIPTION
CircleCI Orbs allow us to share CI configuration across repos. See the docs for more information: https://circleci.com/docs/2.0/orb-intro/

This has the configuration for two orbs:
- android-sdk: Specifically for building and publishing our Android SDK projects
- app-center: Generic Orb for publishing to App Center (surprisingly I couldn't find an Orb already available for this)

I have already published development versions of these Orbs to `rakutentech/android-sdk@dev:0.1.0` and `rakutentech/app-center@dev:0.1.0`. I've tested this on my forked Mini App repo here: 
https://github.com/corycaywood/android-miniapp/blob/ci/orbs/.circleci/config.yml