### PR TITLE
fix: (CircleCI) Pin the android image at api-29 w/ Java 8

### DIFF
--- a/circleci/android-sdk/README.md
+++ b/circleci/android-sdk/README.md
@@ -95,6 +95,10 @@ Finally, when running your job you can convert this base64 string back into a fi
 
 ## Versions
 
+### 0.1.1 (2020-08-19)
+
+- Pin Android image to the latest version of api-29 which supported Java 8.
+
 ### 0.1.0 (2020-07-28)
 
 - Initial release.

--- a/circleci/android-sdk/config.yml
+++ b/circleci/android-sdk/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-android-docker-image: &android-docker-image circleci/android:api-29
+android-docker-image: &android-docker-image circleci/android@sha256:b6646fdf7457f61825526e7bfce364d8e533da6ceb1cdb98e371e94348ecc834
 
 jobs: 
   build:


### PR DESCRIPTION
CircleCI recently updated their Android images to use Java 11 instead of 8. This breaks all of our builds currently, so this commit pins the Android image at the last version which used Java 8. See https://github.com/circleci/circleci-images/issues/503.