### PR TITLE
Publishing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ To ensure usability we follow these rules:
   * AGP 3.6.2 (requires Gradle 5.6.4+).
   * Targets (and builds with) SDK 29.
 
+### 4.3.1 (2020-09-03)
+* **Fixed:** Bintray publishing was failing due to an impcompatibility of the Bintray Gradle plugin with the Android Maven Publish plugin. The Bintray Gradle plugin has been removed so you no longer need to add `com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4` as a plugin dependency.
+
 ### 4.3.0 (2020-08-06)
 * Added config for [creating html version of the userguide markdown](documentation/README.md) and adding it to the generated javadoc.
 

--- a/circleci/app-center/README.md
+++ b/circleci/app-center/README.md
@@ -54,6 +54,10 @@ workflows:
 
 ## Versions
 
+### 0.1.1 (2020-09-03)
+
+- **Fixed:** Publishing was failing when the `notes` parameter contained spaces.
+
 ### 0.1.0 (2020-07-28)
 
 - Initial release.

--- a/circleci/app-center/config.yml
+++ b/circleci/app-center/config.yml
@@ -36,6 +36,6 @@ jobs:
             --group <<parameters.group>>
             --file <<parameters.file>>
             --app <<parameters.app>>
-            --release-notes <<parameters.notes>>
+            --release-notes '<<parameters.notes>>'
             --token <<parameters.token>>
             --quiet

--- a/publish/README.md
+++ b/publish/README.md
@@ -22,20 +22,7 @@ ARTIFACTORY_URL=https://oss.jfrog.org/artifactory/oss-snapshot-local
 ARTIFACTORY_REPO=oss-snapshot-local
 ```
 
-### 2. Add plugins to buildscript
-
-You will need to add the [Bintray Plugin](https://github.com/bintray/gradle-bintray-plugin) to your classpath in your project's `build.gradle`. If you don't plan to publish to Bintray (and only to Artifactory) then you can skip this step.
-
-```groovy
-bulidscript {
-  dependencies {
-    // If publishing to Bintray
-    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-  }
-}
-```
-
-### 3. Apply publishing scripts
+### 2. Apply publishing scripts
 
 Next, in the `build.gradle` file for the module you wish to publish, you can apply the `config/publish/android.gradle` script and configure your publications.
 

--- a/publish/bintray.gradle
+++ b/publish/bintray.gradle
@@ -1,36 +1,28 @@
-apply plugin: 'com.jfrog.bintray'
-
 def user = project.hasProperty('BINTRAY_USER') ? project.BINTRAY_USER : System.getenv('BINTRAY_USER')
 def key = project.hasProperty('BINTRAY_KEY') ? project.BINTRAY_KEY : System.getenv('BINTRAY_KEY')
 def repo = project.hasProperty('BINTRAY_REPO') ? project.BINTRAY_REPO : System.getenv('BINTRAY_REPO')
 def pkgName = project.hasProperty('BINTRAY_PACKAGE_NAME') ? project.BINTRAY_PACKAGE_NAME : System.getenv('BINTRAY_PACKAGE_NAME')
 
-bintray {
-  it.user = user
-  it.key = key
-  publications = publishing.publications.collect{ it.name }
-  pkg {
-    it.repo = repo
-    name = pkgName
-    licenses = ['MIT']
-    vcsUrl = project.scmUrl
-    version {
-      name = project.version
-      desc = project.description
-      released  = new Date()
-      vcsTag = "v$project.version"
+publishing {
+  repositories {
+    maven {
+      it.name "Bintray"
+      credentials {
+        it.username user
+        it.password key
+      }
+      it.url "https://api.bintray.com/maven/$user/$repo/$pkgName/;publish=1"
     }
   }
 }
 
 task ensureBintrayCredentials {
   doFirst {
-    if (!user?.trim() || !key?.trim() || !repo?.trim()) {
+    if (!user?.trim() || !key?.trim() || !repo?.trim() || !pkgName.trim()) {
       throw new GradleException("You must define environment variables for " +
-              "BINTRAY_USER, BINTRAY_KEY, and BINTRAY_REPO.")
+              "BINTRAY_USER, BINTRAY_KEY, BINTRAY_REPO, and BINTRAY_PACKAGE_NAME.")
     }
   }
 }
 
-bintrayUpload.dependsOn ensureBintrayCredentials
-publish.dependsOn bintrayUpload
+publish.dependsOn ensureBintrayCredentials


### PR DESCRIPTION
- Remove bintray plugin and set bintray credentials using maven-publish instead
  - The bintray plugin seems to be incompatible with the new Android maven-publish plugin. Setting up the credentials and URL manually isn't difficult, so I've just removed the plugin. This change doesn't affect the end required environment variables - it just means that the bintray plugin no longer needs to be added to the project dependnencies.

- (circleci) App center: add quotes around release notes
  - This was failing to upload because the string variable is just directly inserted into the command without treating it as a string.