### PR TITLE
feat: Add publication configuration for Java libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ To ensure usability we follow these rules:
   * AGP 4.0.2 (requires Gradle 6.1.1+).
   * Targets (and builds with) SDK 30.
 
+### 6.1.0 (2021-03-05)
+* **Feature:** Added publication configuration for Java libraries.
+
 ### 6.0.0 (2021-03-03)
 * **Feature:** Added Maven Central publishing script.
 * **Removed:** Bintray/JCenter publishing script was removed because these services are being [shutdown](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).

--- a/circleci/android-sdk/README.md
+++ b/circleci/android-sdk/README.md
@@ -95,6 +95,10 @@ Finally, when running your job you can convert this base64 string back into a fi
 
 ## Versions
 
+### 0.2.1 (2021-03-08)
+
+- Fix `after-prepare-steps` property for the `publish` job.
+
 ### 0.2.0 (2020-08-19)
 
 - Pin Android image to the latest version of api-29 which supported Java 8.

--- a/circleci/android-sdk/config.yml
+++ b/circleci/android-sdk/config.yml
@@ -101,6 +101,7 @@ jobs:
       - run: git submodule update --init
       - attach_workspace:
           at: ./
+      - steps: <<parameters.after-prepare-steps>>
       - run:
           name: Current Version
           command: ./gradlew cV

--- a/publish/base-artifact.gradle
+++ b/publish/base-artifact.gradle
@@ -1,0 +1,70 @@
+import java.nio.file.Paths
+
+apply plugin: 'maven-publish'
+
+def javaDocTask = tasks.findByName('generateDoclava')
+task javaDocJar(type: Jar) {
+  if(javaDocTask) {
+    dependsOn javaDocTask
+  }
+  from Paths.get("$buildDir", 'javadocs')
+  archiveClassifier = "javadoc"
+}
+
+def kDocTask = tasks.findByName('dokka')
+task kDocJar(type: Jar) {
+  if (kDocTask) {
+    dependsOn kDocTask
+    from dokka.outputDirectory
+  }
+  archiveClassifier = 'javadoc'
+}
+
+ext.baseArtifact = { Map config ->
+  task javaDocReadmeJar(type: Jar) {
+    def readme = project.hasProperty("readme") ? project.readme : "$projectDir/../README.md"
+    from config.get('readme') ?: readme
+    archiveClassifier = "javadoc"
+  }
+
+  return {
+    artifactId config.get('artifactId') ?: project.name
+    groupId config.get('groupId') ?: project.group
+    version config.get('version') ?: project.version
+
+    if (javaDocTask) {
+      artifact javaDocJar
+    } else if (kDocTask) {
+      artifact kDocJar
+    } else {
+      // Maven Central requires a javadoc JAR even if this is not a Java project
+      artifact javaDocReadmeJar
+    }
+    config.get('artifacts')?.each {
+      artifact it
+    }
+
+    pom {
+      name = config.get('name') ?: project.name
+      description = config.get('description') ?: project.description
+      url = config.get('url') ?: project.url
+      licenses {
+        license {
+          name = config.get('licenseName') ?: project.licenseName
+          url = config.get('licenseUrl') ?: project.licenseUrl
+        }
+      }
+      scm {
+        url = config.get('scmUrl') ?: project.scmUrl
+      }
+      developers {
+        developer {
+          name = config.get('developerName') ?: project.developerName
+          email = config.get('developerEmail') ?: project.developerEmail
+          organization = config.get('developerOrganization') ?: project.developerOrganization
+          organizationUrl = config.get('developerOrganizationUrl') ?: project.developerOrganizationUrl
+        }
+      }
+    }
+  }
+}

--- a/publish/java.gradle
+++ b/publish/java.gradle
@@ -1,18 +1,18 @@
 apply from: "$CONFIG.configDir/publish/base-artifact.gradle"
 
-task androidSourceJar(type: Jar) {
-  from android.sourceSets.main.java.srcDirs
+task javaSourceJar(type: Jar) {
+  from sourceSets.main.allJava
   archiveClassifier = 'sources'
 }
 
-ext.androidArtifact = { Map config ->
+ext.javaArtifact = { Map config ->
   config = config ?: [:]
 
   return baseArtifact(config) << {
-    from config.get('from') ?: components.release
+    from config.get('from') ?: components.java
 
     if (!config.get('excludeSourceJar')) {
-      artifact androidSourceJar
+      artifact javaSourceJar
     }
   }
 }


### PR DESCRIPTION
The [Manifest Config](https://github.com/rakutentech/android-manifest-config) project is a Java library, so we need a slightly different publication configuration for this.

Sorry it looks like a lot of changes, but basically the content of the new `base-artifact.gradle` is almost the same as `android.gradle` was. I just split it into a new file so it can be shared with `java.gradle`. The configuration is almost the same for Java libraries, just the `component` and `sources` are different.