### PR TITLE
(gh-pages-theme) fix: Remove SEO tag and replace with content

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,17 @@
 <meta charset="UTF-8">
 
-{% seo %}
+<title>{{ page.title }} | {{ site.title }}</title>
+
+<meta property="og:title" content="{{ site.title }}" />
+<meta property="og:locale" content="en_US" />
+<meta name="description" content="{{ site.description }}" />
+<meta property="og:description" content="{{ site.description }}" />
+<link rel="canonical" href="{{ site.github.url }}" />
+<meta property="og:url" content="{{ site.github.url }}" />
+<meta property="og:site_name" content="{{ site.title }}" />
+<meta name="twitter:card" content="{{ site.description }}" />
+<meta property="twitter:title" content="{{ page.title }}" />
+
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#157878">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
This fix is for the Github pages theme.

The jekyll-seo-tag plugin is no longer supported by Github Pages, so the seo tag was causing the pages build to fail. Instead I've replaced it with the same content that the tag was generating.