### PR TITLE
build: Update CircleCI docker image to api-30

### DIFF
--- a/circleci/android-sdk/README.md
+++ b/circleci/android-sdk/README.md
@@ -95,6 +95,10 @@ Finally, when running your job you can convert this base64 string back into a fi
 
 ## Versions
 
+### 0.3.0 (2022-01-25)
+
+- Update docker image to `android:api-30`. This docker image uses Java 11, so your project must support building with Java 11
+
 ### 0.2.1 (2021-03-08)
 
 - Fix `after-prepare-steps` property for the `publish` job.

--- a/circleci/android-sdk/config.yml
+++ b/circleci/android-sdk/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 
-android-docker-image: &android-docker-image circleci/android@sha256:b6646fdf7457f61825526e7bfce364d8e533da6ceb1cdb98e371e94348ecc834
+android-docker-image: &android-docker-image circleci/android:api-30
 
 jobs: 
   build:


### PR DESCRIPTION
Previously we were using a fixed version of the docker image which supported Java 8. However, in order to target Android 31 you must build with Java 11, so we must update the docker image to a version which supports Java 11.