### PR TITLE
feat: Added support for Dokka v1.6.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ To ensure usability we follow these rules:
 * Major version changes must also provide a migration guide from the previous major version
 
 ## Versions <a name="versions"></a>
-### HEAD
+### 7.0.0
 * Update versions:
   * AGP 4.0.2 (requires Gradle 6.1.1+).
   * Targets (and builds with) SDK 30.
+* **Updated:** Support for Dokka v1.6.10. This is a BREAKING change. You will need to update your Dokka version and change your dokka configuration as described in the [documentation README](documentation/README.md)
 
 ### 6.2.0 (2021-10-27)
 * **Feature:** Updated `compile` and `target` to API 31, and min to API 23 in `versions.gradle`

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -8,7 +8,7 @@ Configuration to create dokka kdoc or doclava javadoc.
 ```groovy
 // root script
 buildscript {
-  ext.dokka_version = '0.10.0'
+  ext.dokka_version = '1.6.10'
 
   dependencies {
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:${dokka_version}"
@@ -17,12 +17,12 @@ buildscript {
 
 // sub project
 apply from: '../config/documentation/dokka/android.gradle'
-dokka {
-  configuration {
-    sourceRoot {
-      path = "{path to source}"
+dokkaGfm.configure {
+    dokkaSourceSets {
+        named("{source name i.e. 'main'}") {
+            sourceRoots.from(file("{path to source}"))
+        }
     }
-  }
 }
 ```
 

--- a/documentation/dokka/android.gradle
+++ b/documentation/dokka/android.gradle
@@ -2,12 +2,20 @@ apply plugin: 'org.jetbrains.dokka'
 
 def docsBuildDirectory = "$buildDir/kdocs"
 
-dokka {
-  outputFormat = 'markdown'
-  outputDirectory = "$docsBuildDirectory"
-  configuration {
-    includeNonPublic = false
-    skipEmptyPackages = true
+dokkaGfm.configure {
+
+  dokkaSourceSets {
+    configureEach {
+      outputDirectory.set(file("$docsBuildDirectory"))
+      noAndroidSdkLink.set(false)
+      noJdkLink.set(false)
+      noStdlibLink.set(false)
+      noAndroidSdkLink.set(false)
+      includeNonPublic.set(false)
+      skipEmptyPackages.set(true)
+      skipDeprecated.set(false)
+      reportUndocumented.set(true)
+    }
   }
 }
 
@@ -18,8 +26,8 @@ def docsDirectory = "$buildDir/publishableDocs"
 def docsVersionDirectory = "$docsDirectory/docs/$version"
 
 task copyKDocs(type: Copy) {
-  dependsOn dokka
-  from "$docsBuildDirectory/$project.name"
+  dependsOn dokkaGfm
+  from "$docsBuildDirectory"
   into "$docsVersionDirectory/api"
 }
 


### PR DESCRIPTION
This is a breaking change and any project which is currently using Dokka v0.10.0 will need to be updated. This change was necessary becuase the older version of Dokka does not support Kotlin >= 1.4.0