### PR TITLE
feat: create github release plugin (SDKCF 4936)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,22 +55,20 @@ To ensure usability we follow these rules:
 * Major version changes must also provide a migration guide from the previous major version
 
 ## Versions <a name="versions"></a>
+
+### 7.1.0 (2022-03-15)
+
+* **Feature:** Added [Github Release configuration](publish/releases/README.md) for releases and release assets creation.
+* **Feature:** Added [Gitleaks](quality/README.md#gitleaks) tool for detecting and preventing hardcoded secrets.
+
 ### 7.0.0
 * Update versions:
   * AGP 4.0.2 (requires Gradle 6.1.1+).
   * Targets (and builds with) SDK 30.
 * **Updated:** Support for Dokka v1.6.10. This is a BREAKING change. You will need to update your Dokka version and change your dokka configuration as described in the [documentation README](documentation/README.md)
 
-### 6.3.0 (2022-03-15)
-
-* **Feature:** Added [Gitleaks](quality/README.md#gitleaks) tool for detecting and preventing hardcoded secrets.
-
 ### 6.2.0 (2021-10-27)
 * **Feature:** Updated `compile` and `target` to API 31, and min to API 23 in `versions.gradle`
-
-### 6.2.0 (2022-03-15)
-
-* **Feature:** Added [Github Release configuration](publish/releases/README.md) for releases and release assets creation.
 
 ### 6.1.0 (2021-03-05)
 * **Feature:** Added publication configuration for Java libraries.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ To ensure usability we follow these rules:
   * AGP 4.0.2 (requires Gradle 6.1.1+).
   * Targets (and builds with) SDK 30.
 
+### 6.2.0 (2022-03-15)
+
+* **Feature:** Added [Github Release configuration](publish/releases/README.md) for releases and release assets creation.
+
 ### 6.1.0 (2021-03-05)
 * **Feature:** Added publication configuration for Java libraries.
 

--- a/publish/releases/README.md
+++ b/publish/releases/README.md
@@ -1,0 +1,38 @@
+# Github Releases
+
+This configuration is for create releases and release assets to [Github releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).
+Release assets will include the ProGard mapping files generated when building the project.
+
+## Setup
+
+### 1. Add your repository's environment variables
+
+You first need to add the following environment variables to your project:
+
+``` groovy
+// the token you have generated that can be used to access the GitHub API
+// https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token.
+GITHUB_RELEASES_TOKEN="Access token"
+// the repo owner and name eg: https://github.com/{owner}/{repo}
+GITHUB_REPO_OWNER="Repository owner"
+GITHUB_REPO="Repository name"
+```
+
+#### 2. Apply the plugin
+
+Apply the plugin in your top-level `build.gradle` file.
+
+```groovy
+apply from: 'config/publish/releases/github-api.gradle'
+```
+
+### 3. Run the release gradle task
+
+``` shell
+./gradlew build githubRelease
+```
+
+This will do the following:
+
+- Create a new Github release with the current version name. If a tag with the same name already exists, the task will fail with `Status: 422 Unprocessable Entity` server error.
+- Upload the modules mappings zip file to Github Releases assets.  If a file with the same name already exists, the task will fail with `Status: 422 Unprocessable Entity` server error.

--- a/publish/releases/README.md
+++ b/publish/releases/README.md
@@ -13,9 +13,9 @@ You first need to add the following environment variables to your project:
 // the token you have generated that can be used to access the GitHub API
 // https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token.
 GITHUB_RELEASES_TOKEN="Access token"
-// the repo owner and name eg: https://github.com/{owner}/{repo}
-GITHUB_REPO_OWNER="Repository owner"
-GITHUB_REPO="Repository name"
+GITHUB_RELEASES_API_URL="https://api.github.com/repos"
+GITHUB_RELEASES_REPO_OWNER="Repository owner"
+GITHUB_RELEASES_REPO="Repository name"
 ```
 
 #### 2. Apply the plugin

--- a/publish/releases/github-api.gradle
+++ b/publish/releases/github-api.gradle
@@ -21,17 +21,18 @@ task githubRelease(type: GithubReleases,
 
     dependsOn zipAssets
 
-    authToken GITHUB_RELEASES_TOKEN
-    repoOwner GITHUB_REPO_OWNER
-    repo GITHUB_REPO
-    tagName scmVersion.version + new Random().nextInt()
+    baseUrl System.getenv("GITHUB_RELEASES_API_URL")
+    authToken System.getenv("GITHUB_RELEASES_TOKEN")
+    repoOwner System.getenv("GITHUB_RELEASES_REPO_OWNER")
+    repo System.getenv("GITHUB_RELEASES_REPO")
+    tagName scmVersion.version
     releaseName project.name
     file new File("$project.rootDir","/build/mapping/${mappingFileName}")
 }
 
 
 class GithubReleases extends DefaultTask {
-
+    String baseUrl
     String authToken
     String repoOwner
     String repo
@@ -62,7 +63,7 @@ class GithubReleases extends DefaultTask {
 
 
     private void postRelease() {
-        String baseUrl = "https://api.github.com/repos"
+
         String generateReleaseApi = "/${repoOwner}/${repo}/releases"
         String body = "{" +
                 "\"tag_name\":\"$tagName\", " +
@@ -90,10 +91,6 @@ class GithubReleases extends DefaultTask {
     }
 
     private void uploadReleaseAssets() {
-        String baseUrl = "https://uploads.github.com"
-        String uploadReleaseAssetsApi =
-                "/repos/$repoOwner/$repo/releases/$releaseId/assets?name=$file.name"
-        //HttpURLConnection post = new URL("${baseUrl}${uploadReleaseAssetsApi}").openConnection()
         HttpURLConnection post = new URL(uploadAssetsUrl.replace("{?name,label}", "?name=$file.name")).openConnection()
         post.requestMethod = "POST"
         post.doOutput = true

--- a/publish/releases/github-api.gradle
+++ b/publish/releases/github-api.gradle
@@ -1,0 +1,114 @@
+import groovy.json.JsonSlurper
+
+def mappingFileName = "v$scmVersion.version-mapping.zip"
+task zipAssets(type: Zip) {
+    subprojects.each {
+        def assetsPath = new File(rootDir, "$it.name/build/outputs/mapping").absolutePath
+        def outputDir = new File(rootDir, 'build/mapping').absolutePath
+        def nameAndVersion = "$it.name-v$scmVersion.version-mapping"
+        archiveFileName = mappingFileName
+        destinationDirectory = file(outputDir)
+
+        from(assetsPath) {
+            into nameAndVersion
+        }
+    }
+}
+
+task githubRelease(type: GithubReleases,
+        group: 'publishing',
+        description: "release for $name module version $version to Github Releases") {
+
+    dependsOn zipAssets
+
+    authToken GITHUB_RELEASES_TOKEN
+    repoOwner GITHUB_REPO_OWNER
+    repo GITHUB_REPO
+    tagName scmVersion.version
+    releaseName project.name
+    file new File("$project.rootDir","/build/mapping/${mappingFileName}")
+}
+
+
+class GithubReleases extends DefaultTask {
+
+    String authToken
+    String repoOwner
+    String repo
+    String tagName
+    String releaseName
+    File file
+
+    @TaskAction
+    void createRelease() {
+
+        /** Create a Github release.
+         * If a tag with the same name already exist,the task will fail with
+         * `Status: 422 Unprocessable Entity` server error.
+         */
+        def releaseId = postRelease()
+
+        /** Upload Release Assets.
+         * Upload the modules mappings zip file to Github Releases assets.
+         * If a file with the same name already exist,
+         * the task will fail with `Status: 422 Unprocessable Entity` server error.
+         */
+        uploadReleaseAssets(releaseId)
+
+    }
+
+
+    private long postRelease() {
+        String baseUrl = "https://api.github.com/repos"
+        String generateReleaseApi = "/${repoOwner}/${repo}/releases"
+        String body = "{" +
+                "\"tag_name\":\"$tagName\", " +
+                "\"name\":\"$releaseName v$tagName\"" +
+                "}"
+        HttpURLConnection post = new URL("${baseUrl}${generateReleaseApi}").openConnection()
+        post.requestMethod = "POST"
+        post.doOutput = true
+        post.setRequestProperty("Content-Type", "application/json")
+        post.setRequestProperty("Accept", "application/vnd.github.v3+json")
+        post.setRequestProperty("Authorization", "token ${authToken}")
+        post.outputStream.write(body.bytes)
+        post.outputStream.flush()
+
+        if(post.responseCode <= 201) {
+            def response = new JsonSlurper().parseText(post.getInputStream().text)
+            println "Successfully created release $response.id\n" +
+                    "Status $post.responseCode : $post.responseMessage\""
+            return response.id
+        } else {
+            throw new GradleException("Failed to create a release.\nServer returned status " +
+                    "$post.responseCode : $post.responseMessage")
+        }
+    }
+
+    private void uploadReleaseAssets(long releaseId) {
+        String baseUrl = "https://uploads.github.com"
+        println file.name + " " + releaseId
+        String uploadReleaseAssetsApi =
+                "/repos/$repoOwner/$repo/releases/$releaseId/assets?name=$file.name"
+        HttpURLConnection post = new URL("${baseUrl}${uploadReleaseAssetsApi}").openConnection()
+        println post.getURL()
+        post.requestMethod = "POST"
+        post.doOutput = true
+        post.setRequestProperty("Content-Type", "application/zip")
+        post.setRequestProperty("Accept", "application/vnd.github.v3+json")
+        post.setRequestProperty("Authorization", "token ${authToken}")
+        post.outputStream.write(file.bytes)
+        post.outputStream.flush()
+
+        if(post.responseCode <= 201) {
+            println "Successfully uploaded release assets.\n" +
+                    "Status $post.responseCode : $post.responseMessage\""
+        } else {
+            throw new GradleException("Failed to upload release assets.\n" +
+                    "Server returned status $post.responseCode : $post.responseMessage")
+        }
+    }
+
+}
+
+ext.GithubReleases = GithubReleases

--- a/publish/releases/github-api.gradle
+++ b/publish/releases/github-api.gradle
@@ -24,7 +24,7 @@ task githubRelease(type: GithubReleases,
     authToken GITHUB_RELEASES_TOKEN
     repoOwner GITHUB_REPO_OWNER
     repo GITHUB_REPO
-    tagName scmVersion.version
+    tagName scmVersion.version + new Random().nextInt()
     releaseName project.name
     file new File("$project.rootDir","/build/mapping/${mappingFileName}")
 }
@@ -39,6 +39,9 @@ class GithubReleases extends DefaultTask {
     String releaseName
     File file
 
+    private Long releaseId
+    private String uploadAssetsUrl
+
     @TaskAction
     void createRelease() {
 
@@ -46,19 +49,19 @@ class GithubReleases extends DefaultTask {
          * If a tag with the same name already exist,the task will fail with
          * `Status: 422 Unprocessable Entity` server error.
          */
-        def releaseId = postRelease()
+        postRelease()
 
         /** Upload Release Assets.
          * Upload the modules mappings zip file to Github Releases assets.
          * If a file with the same name already exist,
          * the task will fail with `Status: 422 Unprocessable Entity` server error.
          */
-        uploadReleaseAssets(releaseId)
+        uploadReleaseAssets()
 
     }
 
 
-    private long postRelease() {
+    private void postRelease() {
         String baseUrl = "https://api.github.com/repos"
         String generateReleaseApi = "/${repoOwner}/${repo}/releases"
         String body = "{" +
@@ -78,20 +81,20 @@ class GithubReleases extends DefaultTask {
             def response = new JsonSlurper().parseText(post.getInputStream().text)
             println "Successfully created release $response.id\n" +
                     "Status $post.responseCode : $post.responseMessage\""
-            return response.id
+            releaseId = response.id
+            uploadAssetsUrl = response.upload_url
         } else {
             throw new GradleException("Failed to create a release.\nServer returned status " +
                     "$post.responseCode : $post.responseMessage")
         }
     }
 
-    private void uploadReleaseAssets(long releaseId) {
+    private void uploadReleaseAssets() {
         String baseUrl = "https://uploads.github.com"
-        println file.name + " " + releaseId
         String uploadReleaseAssetsApi =
                 "/repos/$repoOwner/$repo/releases/$releaseId/assets?name=$file.name"
-        HttpURLConnection post = new URL("${baseUrl}${uploadReleaseAssetsApi}").openConnection()
-        println post.getURL()
+        //HttpURLConnection post = new URL("${baseUrl}${uploadReleaseAssetsApi}").openConnection()
+        HttpURLConnection post = new URL(uploadAssetsUrl.replace("{?name,label}", "?name=$file.name")).openConnection()
         post.requestMethod = "POST"
         post.doOutput = true
         post.setRequestProperty("Content-Type", "application/zip")

--- a/quality/gitleaks/build.gradle
+++ b/quality/gitleaks/build.gradle
@@ -4,6 +4,11 @@ import java.nio.file.StandardCopyOption
 
 task installGitLeaksHook{
 
+    def enableGitleaks = System.getenv("ENABLE_GITLEAKS") ?: true
+    if(!enableGitleaks) {
+        return
+    }
+
     try {
         "gitleaks version".execute()
     } catch (IOException ignored) {


### PR DESCRIPTION
The plugin will create a new Github release and upload the modules mappings zip file to releases assets when the `./gradlew githubRelease` task is executed.  