### PR TITLE
refactor: make githook plugin optional (SDKCF-2623)

### DIFF
--- a/git-hooks/build.gradle
+++ b/git-hooks/build.gradle
@@ -2,7 +2,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 
-task installLocalGitHook(type: Copy){
+task installLocalGitHook(type: Copy) {
 
     def preCommitSubDirectory = file(Paths.get(rootDir.absolutePath, '.git', 'hooks', 'pre-commit.d'))
     preCommitSubDirectory.mkdir()

--- a/index.gradle
+++ b/index.gradle
@@ -9,7 +9,6 @@ buildscript {
 }
 
 // Apply all configuration files
-apply from: "$CONFIG.configDir/git-hooks/build.gradle"
 apply from: "$CONFIG.configDir/versions/versions.gradle"
 apply from: "$CONFIG.configDir/versions/repositories.gradle"
 

--- a/quality/README.md
+++ b/quality/README.md
@@ -106,7 +106,7 @@ To test it, use the task : `./gradlew detekt`. See [the detekt docs](https://art
 Prevents you from committing passwords and other sensitive information to a git repository.
 
 ```groovy
-// root project
+// sub project
 apply from: "../config/quality/git-leaks/build.gradle"
 ```
 

--- a/quality/checkstyle/java.gradle
+++ b/quality/checkstyle/java.gradle
@@ -39,6 +39,10 @@ task reformatJavaSources(
 
 task installPrecommitHook {
   doLast {
+    if(tasks.findByName("installLocalGitHook") == null) {
+      apply from: "$CONFIG.configDir/git-hooks/build.gradle"
+    }
+
     def hookFile = file(Paths.get(rootDir.absolutePath, '.git', 'hooks', 'pre-commit.d', 'check-style'))
     Files.copy(
         Paths.get(rootDir.absolutePath, 'config', 'quality', 'checkstyle', 'pre-commit'),

--- a/quality/gitleaks/build.gradle
+++ b/quality/gitleaks/build.gradle
@@ -1,11 +1,10 @@
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.nio.file.StandardCopyOption
 
-task installGitLeaksHook{
+task installGitLeaksHook {
 
-    def enableGitleaks = System.getenv("ENABLE_GITLEAKS") ?: true
-    if(!enableGitleaks) {
+    def enableGitleaks = System.getenv("ENABLE_GITLEAKS")
+    if(enableGitleaks == "false") {
         return
     }
 
@@ -16,6 +15,9 @@ task installGitLeaksHook{
         throw new StopExecutionException("gitleaks not found (try running:  brew install gitleaks)")
     }
 
+    if(tasks.findByName("installLocalGitHook") == null) {
+        apply from: "$CONFIG.configDir/git-hooks/build.gradle"
+    }
     def hookFile = file(Paths.get(rootDir.absolutePath, '.git', 'hooks', 'pre-commit.d', 'gitleaks'))
     hookFile.write  "#!/bin/sh\ngitleaks protect --verbose --redact --staged"
     if(Files.exists(Paths.get(rootDir.absolutePath, '.git', 'hooks', 'gitleaks.toml'))) {


### PR DESCRIPTION
Changed the plugin to create the git-hook files only if the plugin is installed in the host project.
Fix the CI environment variable ENABLE_GITLEAKS  type.