### PR TITLE
chore: bump android.plugin to 7.2.0 (SDKCF-4918)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ To ensure usability we follow these rules:
 
 ## Versions <a name="versions"></a>
 
+### 9.0.1 (2022-05-11)
+* **Updated** Android Gradle plugin version to 7.2.0.
+
 ### 9.0.0 (2022-04-12)
 * **Breaking Change:** Renamed `artifactory.gradle` to `repository.gradle`, and project config keys for publishing.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To ensure usability we follow these rules:
 
 ## Versions <a name="versions"></a>
 
-### 9.0.1 (2022-05-11)
+### 9.1.0 (2022-05-11)
 * **Updated** Android Gradle plugin version to 7.2.0.
 
 ### 9.0.0 (2022-04-12)

--- a/buildSrc/src/test/resources/build_script_dependency.gradle
+++ b/buildSrc/src/test/resources/build_script_dependency.gradle
@@ -1,8 +1,8 @@
 buildscript {
   repositories {
-    jcenter()
+    mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.2'
+    classpath 'com.android.tools.build:gradle:7.2.0'
   }
 }

--- a/versions/versions.gradle
+++ b/versions/versions.gradle
@@ -16,7 +16,7 @@ ext.CONFIG.versions = [
             support     : '26.0.0',
             volley      : '1.1.1',
         ],
-        plugin: '7.1.0',
+        plugin: '7.2.0',
         sdk      : [
             compile: 31,
             target : 31,


### PR DESCRIPTION
Bumped android.plugin to 7.2.0 to fix Dependencycheck reported vulnerabilities.